### PR TITLE
Factor out and reduce number of polynomial evaluations

### DIFF
--- a/src/models_1d.jl
+++ b/src/models_1d.jl
@@ -23,7 +23,7 @@ function findlayer(m::SeisModel1D, r::Real)
     r < 0. && throw(DomainError(r, "radius cannot be negative"))
     r > m.a && throw(DomainError(r, "radius is greater than Earth radius for model ($(m.a) km)"))
     for i in 1:length(m.r)
-        r < m.r[i] && return i
+        @inbounds r < m.r[i] && return i
     end
     length(m.r)
 end

--- a/test/models_1d.jl
+++ b/test/models_1d.jl
@@ -52,6 +52,9 @@ using SeisModels
         end
 
         @testset "PREMPolyModels" begin
+            # Polynomial evaluation
+            @test SeisModels._evalpoly(0.25, hcat([0, 0, 0, 0], [1, 2, 3, 4]), 2) == 1.75
+            @test SeisModels._evalpoly(0.25, hcat([1, 2, 3, 4], [0, 0, 0, 0]), 1) == 1.75
             # Velocities default to reference frequency
             for f in (vp, vs, vpv, vsv, vph, vsh)
                 @test f(PREM, 5000) == f(PREM, 5000, freq=reffrequency(PREM))


### PR DESCRIPTION
For PREMPolyModels:
- Replace multiple independent polynomial evaluation locations to
  calls to SeisModels._evalpoly, which retains the same
  implementation.
- When correcting for attenuation, re-use the already-computed
  value for one of Vp or Vs (depending on which function is
  called) to reduce the number of polynomial evaluations required.

These contribute to a small increase in speed for velocity lookups
without correction for attenuation, and much larger speedups
(nearly twice as fast) when correcting for attenuation.