### PR TITLE
Add PREM_NOOCEAN, PREM but without the ocean

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ Currently, only three kinds of one-dimensional models are supported, but all mod
 parameterisations and models are acceptable for inclusion.  Contributions
 are welcome.
 
-Built in models are ak135, PREM, iasp91, and Weber et al. (Science, 2011)'s
-model of the moon.
+Built in models are [listed in the documentation](https://anowacki.github.io/SeisModels.jl/dev/inbuilt_models/).
 
 
 ## How to install
@@ -123,6 +122,7 @@ does support reading and writing of
   - `AK135`
   - `IASP91`
   - `PREM`
+  - `PREM_NOOCEAN`
   - `STW105`
 - Moon
   - `MOON_WEBER_2011`
@@ -163,6 +163,8 @@ does support reading and writing of
 #### IO
 - `read_mineos`: Read Mineos tabular-format file
 - `write_mineos`: Write Mineos tabular-format file
+- `read_tvel`: Write tvel-format file
+- `write_tvel`: Write tvel-format file
 
 
 ## Getting help

--- a/docs/src/inbuilt_models.md
+++ b/docs/src/inbuilt_models.md
@@ -1,7 +1,8 @@
 # Inbuilt models
 
 Most users of SeisModels will probably want to simply calculate
-properties for one of the inbuilt models.  These are listed below:
+properties for one of the inbuilt models, which are all exported.
+These are listed below:
 
 ## Earth models
 ```@docs
@@ -9,6 +10,7 @@ AK135
 EK137
 IASP91
 PREM
+PREM_NOOCEAN
 STW105
 ```
 

--- a/src/Earth/Earth.jl
+++ b/src/Earth/Earth.jl
@@ -14,7 +14,7 @@ List of Earth model instances as `Symbol`s.
 
 If adding new inbuilt Earth models, append the name of the new model to this list
 """
-const ALL_MODELS = (:AK135, :EK137, :IASP91, :PREM, :STW105)
+const ALL_MODELS = (:AK135, :EK137, :IASP91, :PREM, :PREM_NOOCEAN, :STW105)
 
 include("ak135.jl")
 include("ek137.jl")

--- a/src/Earth/prem.jl
+++ b/src/Earth/prem.jl
@@ -57,3 +57,26 @@ const PREM = PREMPolyModel(
     fref =
     1.0
     )
+
+"""
+# `PREM_NOOCEAN`
+
+Version of [`PREM`](@ref) where the liquid ocean layer is replaced by the
+crust beneath.  This model may be useful when the surface must be a solid.
+"""
+const PREM_NOOCEAN = let inds = 1:(PREM.n - 1)
+    PREMPolyModel(
+        r = [PREM.r[1:(PREM.n - 2)]; PREM.a],
+        vp = PREM.vp[:,inds],
+        vs = PREM.vs[:,inds],
+        density = PREM.density[:,inds],
+        vph = PREM.vph[:,inds],
+        vpv = PREM.vpv[:,inds],
+        vsh = PREM.vsh[:,inds],
+        vsv = PREM.vsv[:,inds],
+        eta = PREM.eta[:,inds],
+        Qμ = PREM.Qμ[:,inds],
+        Qκ = PREM.Qκ[:,inds],
+        fref = PREM.fref
+    )
+end

--- a/test/inbuilt_models.jl
+++ b/test/inbuilt_models.jl
@@ -48,6 +48,20 @@ using SeisModels
             @test gravity(PREM, surface_radius(PREM)) ≈ 9.81 atol=0.02
         end
 
+        @testset "PREM_NOOCEAN" begin
+            @test surface_radius(PREM_NOOCEAN) == surface_radius(PREM)
+            @test length(PREM_NOOCEAN.r) == length(PREM.r) - 1
+            @test isanisotropic(PREM_NOOCEAN)
+            @test vp(PREM_NOOCEAN, 0) ≈ 11.2622
+            @test hasattenuation(PREM_NOOCEAN)
+            @test hasreffrequency(PREM_NOOCEAN)
+            @test reffrequency(PREM_NOOCEAN) == 1.0
+            @test Qμ(PREM_NOOCEAN, 0, depth=true) == 600.0
+            @test eta(PREM_NOOCEAN, 0, depth=true) == 1.0
+            @test vp(PREM_NOOCEAN, 0, depth=true) == 5.8
+            @test vsv(PREM_NOOCEAN, 0, depth=true) == 3.2
+        end
+
         @testset "STW105" begin
             @test surface_radius(STW105) == 6371.0
             @test isanisotropic(STW105)


### PR DESCRIPTION
This model is used by other packages (e.g., SPECFEM, TauP) since
it avoids the liquid layer at the surface, which is tricky for
some calculations.  It simply removes the ocean and continues the
layer below to the surface, thus has slightly higher mass and
gravity.