### PR TITLE
fix: Add missing inbuilt models to REPL help

### DIFF
--- a/src/SeisModels.jl
+++ b/src/SeisModels.jl
@@ -54,9 +54,12 @@ Derived properties can be computed for all models with density:
 ### Inbuilt models
 
 - Earth
-  - `PREM`
-  - `IASP91`
   - `AK135`
+  - `EK137`
+  - `IASP91`
+  - `PREM`
+  - `PREM_NOOCEAN`
+  - `STW105`
 - Moon
   - `MOON_WEBER_2011`
 """


### PR DESCRIPTION
Just a small fix. Maybe there is a way to splice the REPL help into the docs somehow to avoid the duplication, but I guess that might involve some restructuring of the markdown files which might not be desired, so I'm just putting this simple fix here first.
