### PR TITLE
Bump min Julia to v1.6 and fix macOS runners

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -16,14 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
           - '1.6'
           - '1'
           - 'nightly'
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
         arch:
           - x64
         include:
@@ -33,6 +31,15 @@ jobs:
           - os: ubuntu-latest
             version: '1'
             arch: x86
+          - os: macos-latest
+            version: '1.10'
+            arch: aarch64
+          - os: macos-latest
+            version: '1'
+            arch: aarch64
+          - os: macos-latest
+            version: 'nightly'
+            arch: aarch64
 
     steps:
       - uses: actions/checkout@v6

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
 [compat]
 DelimitedFiles = "1"
 QuadGK = "1, 2"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
macOS runners on GitHub Actions are now all Apple Silicon, so
trying to run them with an `arch` of `x64` led to failures.  Allow
macOS runners to be `aarch64` instead.

In the process, bump the minimum Julia version to v1.6.
